### PR TITLE
Rearranged source code to support QMK's way of compiling from JSON

### DIFF
--- a/keyboards/chonkerkeys/core.c
+++ b/keyboards/chonkerkeys/core.c
@@ -3,19 +3,16 @@
 #include "rgb_strands/rgb_strands.h"
 #include <math.h>
 
-// This file is not meant to be compiled directly, but included in keymap.c
-// LAYER_COUNT, keymaps etc are defined in config.c
-
-#define LAYER_COUNT 2
+extern const uint8_t layer_count;
 extern const uint32_t firmware_version;
-extern const uint8_t layers[LAYER_COUNT];
+extern const uint8_t layers[];
 extern const uint64_t icons[MATRIX_ROWS][MATRIX_COLS];
-extern const uint8_t PROGMEM key_size_and_ordinals[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
-extern const uint32_t PROGMEM inactive_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
-extern const uint32_t PROGMEM active_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
-extern const uint16_t PROGMEM keymaps[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
-extern const uint16_t PROGMEM custom_actions[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS][3];
-extern const uint8_t PROGMEM key_anim[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
+extern const uint8_t PROGMEM key_size_and_ordinals[][MATRIX_ROWS][MATRIX_COLS];
+extern const uint32_t PROGMEM inactive_colors[][MATRIX_ROWS][MATRIX_COLS];
+extern const uint32_t PROGMEM active_colors[][MATRIX_ROWS][MATRIX_COLS];
+extern const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS];
+extern const uint16_t PROGMEM custom_actions[][MATRIX_ROWS][MATRIX_COLS][3];
+extern const uint8_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS];
 
 bool is_connected = false;
 
@@ -80,7 +77,7 @@ const uint16_t macos_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
 };
 
 uint8_t get_layer_count() {
-    return LAYER_COUNT;
+    return layer_count;
 }
 
 uint8_t get_layer_type(uint8_t index) {
@@ -124,7 +121,7 @@ bool is_windows(uint8_t layer) {
 
 uint16_t get_current_layer(void) {
     uint16_t current_layer = 0;
-    for (uint16_t i = 0; i < LAYER_COUNT; ++i) {
+    for (uint16_t i = 0; i < layer_count; ++i) {
         if (IS_LAYER_ON(i)) {
             current_layer = i;
             break;
@@ -141,7 +138,7 @@ void switch_layer(uint16_t index) {
 void switch_to_next_layer(void) {
     uint16_t current_layer = get_current_layer();
     uint16_t next_layer = current_layer + 1;
-    if (next_layer >= LAYER_COUNT) {
+    if (next_layer >= layer_count) {
         next_layer = 0;
     }
     switch_layer(next_layer);
@@ -321,7 +318,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-  for (uint32_t i = 0; i < LAYER_COUNT; ++i) {
+  for (uint32_t i = 0; i < layer_count; ++i) {
       if (IS_LAYER_ON_STATE(state, i)) {
           layer_switched(i);
           break;

--- a/keyboards/chonkerkeys/core.c
+++ b/keyboards/chonkerkeys/core.c
@@ -16,66 +16,6 @@ extern const uint8_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS];
 
 bool is_connected = false;
 
-const uint16_t windows_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
-    { KC_NO, KC_NO, KC_NO },
-    // zoom
-    { KC_LALT, KC_A, KC_NO },
-    { KC_LALT, KC_V, KC_NO },
-    { KC_LALT, KC_S, KC_NO },
-    { KC_LALT, KC_Y, KC_NO },
-    { KC_LALT, KC_Q, KC_NO },
-    // teams
-    { KC_LCTRL, KC_LSHIFT, KC_M },
-    { KC_LCTRL, KC_LSHIFT, KC_O },
-    { KC_LCTRL, KC_LSHIFT, KC_E },
-    { KC_LCTRL, KC_LSHIFT, KC_K },
-    { KC_LCTRL, KC_LSHIFT, KC_H },
-    // skype
-    { KC_LCTRL, KC_M, KC_NO },
-    { KC_LCTRL, KC_LSHIFT, KC_K },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_LCTRL, KC_LSHIFT, KC_H },
-    // google meet
-    { KC_LCTRL, KC_D, KC_NO },
-    { KC_LCTRL, KC_E, KC_NO },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_LCTRL, KC_LALT, KC_H },
-    { KC_LALT, KC_F4, KC_NO },
-    // rest
-    { KC_LALT, KC_TAB, KC_NO },
-};
-
-const uint16_t macos_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
-    { KC_NO, KC_NO, KC_NO },
-    // zoom
-    { KC_LGUI, KC_LSHIFT, KC_A },
-    { KC_LGUI, KC_LSHIFT, KC_V },
-    { KC_LGUI, KC_LSHIFT, KC_S },
-    { KC_LALT, KC_Y, KC_NO },
-    { KC_LGUI, KC_W, KC_NO },
-    // teams
-    { KC_LSHIFT, KC_LGUI, KC_M },
-    { KC_LCTRL, KC_LGUI, KC_O },
-    { KC_LCTRL, KC_LGUI, KC_E },
-    { KC_LCTRL, KC_LGUI, KC_K },
-    { KC_LCTRL, KC_LGUI, KC_H },
-    // skype
-    { KC_LSHIFT, KC_LGUI, KC_M },
-    { KC_LSHIFT, KC_LGUI, KC_K },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_LSHIFT, KC_LGUI, KC_H },
-    // google meet
-    { KC_LGUI, KC_D, KC_NO },
-    { KC_LGUI, KC_E, KC_NO },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_LCTRL, KC_LGUI, KC_H },
-    { KC_NO, KC_NO, KC_NO },
-    // rest
-    { KC_LGUI, KC_TAB, KC_NO },
-};
-
 uint8_t get_layer_count() {
     return layer_count;
 }

--- a/keyboards/chonkerkeys/core.c
+++ b/keyboards/chonkerkeys/core.c
@@ -310,11 +310,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             const rgb_strand_anim_config_t *dcfg = get_default_rgb_strand_anim_config(anim);
             rgb_strand_anim_config_t cfg;
             memcpy(&cfg, dcfg, sizeof(rgb_strand_anim_config_t));
-            uint32_t color = get_key_active_color(current_layer, col, row);
-            uint8_t r = (uint8_t) (color >> 24) && 0xff;
-            uint8_t g = (uint8_t) (color >> 16) && 0xff;
-            uint8_t b = (uint8_t) (color >> 8) && 0xff;
-            set_rgb_strand_config_color(&cfg, r, g, b);
             rgb_strand_animation_start(key_strand, anim,
                     &cfg,
                     RGB_STRAND_ANIM_STATE_STEADY);

--- a/keyboards/chonkerkeys/core.c
+++ b/keyboards/chonkerkeys/core.c
@@ -6,7 +6,78 @@
 // This file is not meant to be compiled directly, but included in keymap.c
 // LAYER_COUNT, keymaps etc are defined in config.c
 
+#define LAYER_COUNT 2
+extern const uint32_t firmware_version;
+extern const uint8_t layers[LAYER_COUNT];
+extern const uint64_t icons[MATRIX_ROWS][MATRIX_COLS];
+extern const uint8_t key_size_and_ordinals[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
+extern const uint32_t PROGMEM inactive_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
+extern const uint32_t PROGMEM active_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
+extern const uint16_t PROGMEM keymaps[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
+extern const uint16_t PROGMEM custom_actions[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS][3];
+extern const rgb_strands_anim_t key_anim[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
+
 bool is_connected = false;
+
+const uint16_t windows_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LALT, KC_A, KC_NO },
+    { KC_LALT, KC_V, KC_NO },
+    { KC_LALT, KC_S, KC_NO },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LALT, KC_Q, KC_NO },
+    // teams
+    { KC_LCTRL, KC_LSHIFT, KC_M },
+    { KC_LCTRL, KC_LSHIFT, KC_O },
+    { KC_LCTRL, KC_LSHIFT, KC_E },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // skype
+    { KC_LCTRL, KC_M, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // google meet
+    { KC_LCTRL, KC_D, KC_NO },
+    { KC_LCTRL, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LALT, KC_H },
+    { KC_LALT, KC_F4, KC_NO },
+    // rest
+    { KC_LALT, KC_TAB, KC_NO },
+};
+
+const uint16_t macos_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LGUI, KC_LSHIFT, KC_A },
+    { KC_LGUI, KC_LSHIFT, KC_V },
+    { KC_LGUI, KC_LSHIFT, KC_S },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LGUI, KC_W, KC_NO },
+    // teams
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LCTRL, KC_LGUI, KC_O },
+    { KC_LCTRL, KC_LGUI, KC_E },
+    { KC_LCTRL, KC_LGUI, KC_K },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    // skype
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LSHIFT, KC_LGUI, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LSHIFT, KC_LGUI, KC_H },
+    // google meet
+    { KC_LGUI, KC_D, KC_NO },
+    { KC_LGUI, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    { KC_NO, KC_NO, KC_NO },
+    // rest
+    { KC_LGUI, KC_TAB, KC_NO },
+};
 
 uint8_t get_layer_count() {
     return LAYER_COUNT;

--- a/keyboards/chonkerkeys/core.c
+++ b/keyboards/chonkerkeys/core.c
@@ -10,12 +10,12 @@
 extern const uint32_t firmware_version;
 extern const uint8_t layers[LAYER_COUNT];
 extern const uint64_t icons[MATRIX_ROWS][MATRIX_COLS];
-extern const uint8_t key_size_and_ordinals[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
+extern const uint8_t PROGMEM key_size_and_ordinals[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
 extern const uint32_t PROGMEM inactive_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
 extern const uint32_t PROGMEM active_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
 extern const uint16_t PROGMEM keymaps[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
 extern const uint16_t PROGMEM custom_actions[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS][3];
-extern const rgb_strands_anim_t key_anim[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
+extern const uint8_t PROGMEM key_anim[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS];
 
 bool is_connected = false;
 
@@ -220,7 +220,7 @@ void set_rgb_strand_config_color(rgb_strand_anim_config_t* cfg, uint8_t r, uint8
     cfg->color.v = (uint8_t) (v / 100.0f * 255.0f);
 }
 
-void start_key_anim(uint8_t x, uint8_t y, rgb_strands_anim_t anim, uint8_t r, uint8_t g, uint8_t b) {
+void start_key_anim(uint8_t x, uint8_t y, uint8_t anim, uint8_t r, uint8_t g, uint8_t b) {
     from_app_to_firmware_origin(&x, &y);
     uint8_t rgb_strand = from_x_y_to_index(x, y);
     const rgb_strand_anim_config_t *dcfg = get_default_rgb_strand_anim_config(anim);
@@ -306,7 +306,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 unregister_code(keycode);
             }
             uint8_t current_layer = get_current_layer();
-            rgb_strands_anim_t anim = pgm_read_byte(&key_anim[current_layer][row][col]);
+            uint8_t anim = pgm_read_byte(&key_anim[current_layer][row][col]);
             const rgb_strand_anim_config_t *dcfg = get_default_rgb_strand_anim_config(anim);
             rgb_strand_anim_config_t cfg;
             memcpy(&cfg, dcfg, sizeof(rgb_strand_anim_config_t));

--- a/keyboards/chonkerkeys/gen/src/ch-qmk-gen.py
+++ b/keyboards/chonkerkeys/gen/src/ch-qmk-gen.py
@@ -117,7 +117,7 @@ c_output += "const uint16_t PROGMEM custom_actions[LAYER_COUNT][MATRIX_ROWS][MAT
 c_output += print_array(customActions, 0)
 c_output += ";\n"
 c_output += "\n"
-c_output += "const rgb_strands_anim_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS] = "
+c_output += "const uint8_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS] = "
 c_output += print_array(animations, 0)
 c_output += ";\n"
 

--- a/keyboards/chonkerkeys/keyconfig.h
+++ b/keyboards/chonkerkeys/keyconfig.h
@@ -35,64 +35,7 @@ enum custom_keycodes {
 };
 
 #define KEY_MACROS_MAX_COUNT  3
-#define KEYCODE_COUNT 22
+#define KEYCODE_COUNT (CH_LAST_KEYCODE - CH_CUSTOM)
 
-const uint16_t windows_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
-    { KC_NO, KC_NO, KC_NO },
-    // zoom
-    { KC_LALT, KC_A, KC_NO },
-    { KC_LALT, KC_V, KC_NO },
-    { KC_LALT, KC_S, KC_NO },
-    { KC_LALT, KC_Y, KC_NO },
-    { KC_LALT, KC_Q, KC_NO },
-    // teams
-    { KC_LCTRL, KC_LSHIFT, KC_M },
-    { KC_LCTRL, KC_LSHIFT, KC_O },
-    { KC_LCTRL, KC_LSHIFT, KC_E },
-    { KC_LCTRL, KC_LSHIFT, KC_K },
-    { KC_LCTRL, KC_LSHIFT, KC_H },
-    // skype
-    { KC_LCTRL, KC_M, KC_NO },
-    { KC_LCTRL, KC_LSHIFT, KC_K },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_LCTRL, KC_LSHIFT, KC_H },
-    // google meet
-    { KC_LCTRL, KC_D, KC_NO },
-    { KC_LCTRL, KC_E, KC_NO },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_LCTRL, KC_LALT, KC_H },
-    { KC_LALT, KC_F4, KC_NO },
-    // rest
-    { KC_LALT, KC_TAB, KC_NO },
-};
-
-const uint16_t macos_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
-    { KC_NO, KC_NO, KC_NO },
-    // zoom
-    { KC_LGUI, KC_LSHIFT, KC_A },
-    { KC_LGUI, KC_LSHIFT, KC_V },
-    { KC_LGUI, KC_LSHIFT, KC_S },
-    { KC_LALT, KC_Y, KC_NO },
-    { KC_LGUI, KC_W, KC_NO },
-    // teams
-    { KC_LSHIFT, KC_LGUI, KC_M },
-    { KC_LCTRL, KC_LGUI, KC_O },
-    { KC_LCTRL, KC_LGUI, KC_E },
-    { KC_LCTRL, KC_LGUI, KC_K },
-    { KC_LCTRL, KC_LGUI, KC_H },
-    // skype
-    { KC_LSHIFT, KC_LGUI, KC_M },
-    { KC_LSHIFT, KC_LGUI, KC_K },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_LSHIFT, KC_LGUI, KC_H },
-    // google meet
-    { KC_LGUI, KC_D, KC_NO },
-    { KC_LGUI, KC_E, KC_NO },
-    { KC_NO, KC_NO, KC_NO },
-    { KC_LCTRL, KC_LGUI, KC_H },
-    { KC_NO, KC_NO, KC_NO },
-    // rest
-    { KC_LGUI, KC_TAB, KC_NO },
-};
+extern const uint16_t windows_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT];
+extern const uint16_t macos_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT];

--- a/keyboards/chonkerkeys/max/keymaps/default/config.c.template
+++ b/keyboards/chonkerkeys/max/keymaps/default/config.c.template
@@ -320,7 +320,7 @@ const uint16_t PROGMEM custom_actions[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS][3] 
     }
 };
 
-const rgb_strands_anim_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS] = {
+const uint8_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS] = {
     {
         {
             RGB_STRAND_EFFECT_NONE,

--- a/keyboards/chonkerkeys/max/keymaps/default/config.c.template
+++ b/keyboards/chonkerkeys/max/keymaps/default/config.c.template
@@ -12,6 +12,66 @@ const uint8_t layers[LAYER_COUNT] = {
     CH_ZOOM_MACOS
 };
 
+const uint16_t windows_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LALT, KC_A, KC_NO },
+    { KC_LALT, KC_V, KC_NO },
+    { KC_LALT, KC_S, KC_NO },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LALT, KC_Q, KC_NO },
+    // teams
+    { KC_LCTRL, KC_LSHIFT, KC_M },
+    { KC_LCTRL, KC_LSHIFT, KC_O },
+    { KC_LCTRL, KC_LSHIFT, KC_E },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // skype
+    { KC_LCTRL, KC_M, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // google meet
+    { KC_LCTRL, KC_D, KC_NO },
+    { KC_LCTRL, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LALT, KC_H },
+    { KC_LALT, KC_F4, KC_NO },
+    // rest
+    { KC_LALT, KC_TAB, KC_NO },
+};
+
+const uint16_t macos_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LGUI, KC_LSHIFT, KC_A },
+    { KC_LGUI, KC_LSHIFT, KC_V },
+    { KC_LGUI, KC_LSHIFT, KC_S },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LGUI, KC_W, KC_NO },
+    // teams
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LCTRL, KC_LGUI, KC_O },
+    { KC_LCTRL, KC_LGUI, KC_E },
+    { KC_LCTRL, KC_LGUI, KC_K },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    // skype
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LSHIFT, KC_LGUI, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LSHIFT, KC_LGUI, KC_H },
+    // google meet
+    { KC_LGUI, KC_D, KC_NO },
+    { KC_LGUI, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    { KC_NO, KC_NO, KC_NO },
+    // rest
+    { KC_LGUI, KC_TAB, KC_NO },
+};
+
 const uint64_t icons[MATRIX_ROWS][MATRIX_COLS] = {
     {
         0,

--- a/keyboards/chonkerkeys/max/keymaps/default/config.c.template
+++ b/keyboards/chonkerkeys/max/keymaps/default/config.c.template
@@ -5,6 +5,8 @@ const uint32_t firmware_version = 1;
 
 #define LAYER_COUNT 2
 
+const uint8_t layer_count = LAYER_COUNT;
+
 const uint8_t layers[LAYER_COUNT] = {
     CH_ZOOM_WINDOWS,
     CH_ZOOM_MACOS

--- a/keyboards/chonkerkeys/max/keymaps/default/keymap.c
+++ b/keyboards/chonkerkeys/max/keymaps/default/keymap.c
@@ -15,7 +15,5 @@
  */
 #include QMK_KEYBOARD_H
 #include "virtser.h"
-#include "../protocol.c"
 #include "config.c"
 
-#include "../core.c"

--- a/keyboards/chonkerkeys/max/max.c
+++ b/keyboards/chonkerkeys/max/max.c
@@ -14,4 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include QMK_KEYBOARD_H
+#include "virtser.h"
 #include "max.h"
+
+#include "../protocol.c"
+#include "../core.c"

--- a/keyboards/chonkerkeys/max/max.h
+++ b/keyboards/chonkerkeys/max/max.h
@@ -17,21 +17,3 @@
 #pragma once
 
 #include "quantum.h"
-
-/* This is a shortcut to help you visually see your layout.
- *
- * The first section contains all of the arguments representing the physical
- * layout of the board and position of the keys.
- *
- * The second converts the arguments into a two-dimensional array which
- * represents the switch matrix.
- */
-#define LAYOUT( \
-    k00, k01, k02, k03, \
-    k10, k11, k12, k13, \
-    k20, k21, k22, k23 \
-) { \
-    { k00, k01, k02, k03 }, \
-    { k10, k11, k12, k13 }, \
-    { k20, k21, k22, k23 } \
-}

--- a/keyboards/chonkerkeys/max/templates/chonkerkeys_max.json
+++ b/keyboards/chonkerkeys/max/templates/chonkerkeys_max.json
@@ -1,0 +1,9 @@
+{
+    "___comment": "PLACEHOLDER FOR NOW",
+    "keyboard": "chonkerkeys/max",
+    "keymap": "default",
+    "layout": "LAYOUT_all",
+    "layers": [
+        [], [], []
+    ]
+}

--- a/keyboards/chonkerkeys/max/templates/keymap.c
+++ b/keyboards/chonkerkeys/max/templates/keymap.c
@@ -1,0 +1,499 @@
+/**
+ * TODO: MAKE THIS CONFIGURABLE NOT HARD-CODED
+ */
+#include QMK_KEYBOARD_H
+#include "rgb_strands.h"
+
+// Defines the keycodes used by our macros in process_record_user
+enum custom_keycodes {
+    CH_CUSTOM = SAFE_RANGE,
+    // zoom
+    CH_ZOOM_MUTE_TOGGLE,
+    CH_ZOOM_VIDEO_TOGGLE,
+    CH_ZOOM_SHARE_SCREEN_START_STOP_TOGGLE,
+    CH_ZOOM_RAISE_HAND_TOGGLE,
+    CH_ZOOM_LEAVE_MEETING,
+    // teams
+    CH_TEAMS_MUTE_TOGGLE,
+    CH_TEAMS_VIDEO_TOGGLE,
+    CH_TEAMS_SHARE_SCREEN_START_STOP_TOGGLE,
+    CH_TEAMS_RAISE_HAND_TOGGLE,
+    CH_TEAMS_LEAVE_MEETING,
+    // skype
+    CH_SKYPE_MUTE_TOGGLE,
+    CH_SKYPE_VIDEO_TOGGLE,
+    CH_SKYPE_SHARE_SCREEN_START_STOP_TOGGLE,
+    CH_SKYPE_RAISE_HAND_TOGGLE,
+    CH_SKYPE_LEAVE_MEETING,
+    // google meet
+    CH_GOOGLE_MEET_MUTE_TOGGLE,
+    CH_GOOGLE_MEET_VIDEO_TOGGLE,
+    CH_GOOGLE_MEET_SHARE_SCREEN_START_STOP_TOGGLE,
+    CH_GOOGLE_MEET_RAISE_HAND_TOGGLE,
+    CH_GOOGLE_MEET_LEAVE_MEETING,
+    // rest
+    CH_SWITCH_WINDOW,
+    CH_LAST_KEYCODE
+};
+
+#define KEY_MACROS_MAX_COUNT  3
+#define KEYCODE_COUNT (CH_LAST_KEYCODE - CH_CUSTOM)
+
+const uint16_t windows_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LALT, KC_A, KC_NO },
+    { KC_LALT, KC_V, KC_NO },
+    { KC_LALT, KC_S, KC_NO },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LALT, KC_Q, KC_NO },
+    // teams
+    { KC_LCTRL, KC_LSHIFT, KC_M },
+    { KC_LCTRL, KC_LSHIFT, KC_O },
+    { KC_LCTRL, KC_LSHIFT, KC_E },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // skype
+    { KC_LCTRL, KC_M, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // google meet
+    { KC_LCTRL, KC_D, KC_NO },
+    { KC_LCTRL, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LALT, KC_H },
+    { KC_LALT, KC_F4, KC_NO },
+    // rest
+    { KC_LALT, KC_TAB, KC_NO },
+};
+
+const uint16_t macos_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LGUI, KC_LSHIFT, KC_A },
+    { KC_LGUI, KC_LSHIFT, KC_V },
+    { KC_LGUI, KC_LSHIFT, KC_S },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LGUI, KC_W, KC_NO },
+    // teams
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LCTRL, KC_LGUI, KC_O },
+    { KC_LCTRL, KC_LGUI, KC_E },
+    { KC_LCTRL, KC_LGUI, KC_K },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    // skype
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LSHIFT, KC_LGUI, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LSHIFT, KC_LGUI, KC_H },
+    // google meet
+    { KC_LGUI, KC_D, KC_NO },
+    { KC_LGUI, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    { KC_NO, KC_NO, KC_NO },
+    // rest
+    { KC_LGUI, KC_TAB, KC_NO },
+};
+
+enum layer_type {
+    CH_CUSTOM_WINDOWS,
+    CH_CUSTOM_MACOS,
+    CH_ZOOM_WINDOWS,
+    CH_ZOOM_MACOS,
+    CH_TEAMS_WINDOWS,
+    CH_TEAMS_MACOS,
+    CH_SKYPE_WINDOWS,
+    CH_SKYPE_MACOS,
+    CH_GOOGLE_MEET_WINDOWS,
+    CH_GOOGLE_MEET_MACOS,
+};
+
+const uint32_t firmware_version = 1;
+
+#define LAYER_COUNT 2
+
+const uint8_t layer_count = LAYER_COUNT;
+
+const uint8_t layers[LAYER_COUNT] = {
+    CH_ZOOM_WINDOWS,
+    CH_ZOOM_MACOS
+};
+
+const uint64_t icons[MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        0,
+        0,
+        1280,
+        0
+    },
+    {
+        2048,
+        1536,
+        1024,
+        512
+    },
+    {
+        2304,
+        1792,
+        768,
+        256
+    }
+};
+
+const uint8_t key_size_and_ordinals[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        {
+            0,
+            0,
+            129,
+            0
+        },
+        {
+            1,
+            1,
+            1,
+            68
+        },
+        {
+            1,
+            1,
+            1,
+            68
+        }
+    },
+    {
+        {
+            0,
+            0,
+            129,
+            0
+        },
+        {
+            1,
+            1,
+            1,
+            68
+        },
+        {
+            1,
+            1,
+            1,
+            68
+        }
+    }
+};
+
+const uint32_t PROGMEM inactive_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        {
+            0,
+            0,
+            0,
+            0
+        },
+        {
+            0,
+            0,
+            0,
+            4278190080
+        },
+        {
+            0,
+            0,
+            4294901760,
+            4278190080
+        }
+    },
+    {
+        {
+            0,
+            0,
+            0,
+            0
+        },
+        {
+            0,
+            0,
+            0,
+            4278190080
+        },
+        {
+            0,
+            0,
+            4294901760,
+            4278190080
+        }
+    }
+};
+
+const uint32_t PROGMEM active_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        {
+            4294967295,
+            4294967295,
+            4294967295,
+            4294967295
+        },
+        {
+            4294967295,
+            4294967295,
+            16711680,
+            16711680
+        },
+        {
+            4294967295,
+            4294967295,
+            16711680,
+            16711680
+        }
+    },
+    {
+        {
+            4294967295,
+            4294967295,
+            4294967295,
+            4294967295
+        },
+        {
+            4294967295,
+            4294967295,
+            16711680,
+            16711680
+        },
+        {
+            4294967295,
+            4294967295,
+            16711680,
+            16711680
+        }
+    }
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        {
+            KC_NO,
+            KC_NO,
+            KC_NO,
+            KC_NO
+        },
+        {
+            KC_MEDIA_NEXT_TRACK,
+            KC_AUDIO_VOL_UP,
+            CH_GOOGLE_MEET_RAISE_HAND_TOGGLE,
+            CH_ZOOM_VIDEO_TOGGLE
+        },
+        {
+            KC_MEDIA_PLAY_PAUSE,
+            KC_AUDIO_VOL_DOWN,
+            CH_GOOGLE_MEET_SHARE_SCREEN_START_STOP_TOGGLE,
+            CH_ZOOM_MUTE_TOGGLE
+        }
+    },
+    {
+        {
+            KC_NO,
+            KC_NO,
+            CH_ZOOM_LEAVE_MEETING,
+            KC_NO
+        },
+        {
+            KC_MEDIA_NEXT_TRACK,
+            KC_AUDIO_VOL_UP,
+            CH_ZOOM_RAISE_HAND_TOGGLE,
+            CH_ZOOM_VIDEO_TOGGLE
+        },
+        {
+            KC_MEDIA_PLAY_PAUSE,
+            KC_AUDIO_VOL_DOWN,
+            CH_ZOOM_SHARE_SCREEN_START_STOP_TOGGLE,
+            CH_ZOOM_MUTE_TOGGLE
+        }
+    }
+};
+
+const uint16_t PROGMEM custom_actions[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS][3] = {
+    {
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        },
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        },
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        }
+    },
+    {
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        },
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        },
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        }
+    }
+};
+
+const uint8_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        {
+            RGB_STRAND_EFFECT_STATIC, // for testing
+            RGB_STRAND_EFFECT_STATIC, // for testing
+            RGB_STRAND_EFFECT_DRAINSWIRL,
+            RGB_STRAND_EFFECT_STATIC  // for testing
+        },
+        {
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_LIKE,
+            RGB_STRAND_EFFECT_MOMENTARY
+        },
+        {
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_BLINKY,
+            RGB_STRAND_EFFECT_MOMENTARY
+        }
+    },
+    {
+        {
+            RGB_STRAND_EFFECT_STATIC, // for testing
+            RGB_STRAND_EFFECT_STATIC, // for testing
+            RGB_STRAND_EFFECT_DRAINSWIRL,
+            RGB_STRAND_EFFECT_STATIC  // for testing
+        },
+        {
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_LIKE,
+            RGB_STRAND_EFFECT_MOMENTARY
+        },
+        {
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_BLINKY,
+            RGB_STRAND_EFFECT_MOMENTARY
+        }
+    }
+};

--- a/keyboards/chonkerkeys/original/keymaps/default/config.c.template
+++ b/keyboards/chonkerkeys/original/keymaps/default/config.c.template
@@ -12,6 +12,66 @@ const uint8_t layers[LAYER_COUNT] = {
     CH_ZOOM_MACOS
 };
 
+const uint16_t windows_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LALT, KC_A, KC_NO },
+    { KC_LALT, KC_V, KC_NO },
+    { KC_LALT, KC_S, KC_NO },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LALT, KC_Q, KC_NO },
+    // teams
+    { KC_LCTRL, KC_LSHIFT, KC_M },
+    { KC_LCTRL, KC_LSHIFT, KC_O },
+    { KC_LCTRL, KC_LSHIFT, KC_E },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // skype
+    { KC_LCTRL, KC_M, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // google meet
+    { KC_LCTRL, KC_D, KC_NO },
+    { KC_LCTRL, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LALT, KC_H },
+    { KC_LALT, KC_F4, KC_NO },
+    // rest
+    { KC_LALT, KC_TAB, KC_NO },
+};
+
+const uint16_t macos_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LGUI, KC_LSHIFT, KC_A },
+    { KC_LGUI, KC_LSHIFT, KC_V },
+    { KC_LGUI, KC_LSHIFT, KC_S },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LGUI, KC_W, KC_NO },
+    // teams
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LCTRL, KC_LGUI, KC_O },
+    { KC_LCTRL, KC_LGUI, KC_E },
+    { KC_LCTRL, KC_LGUI, KC_K },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    // skype
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LSHIFT, KC_LGUI, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LSHIFT, KC_LGUI, KC_H },
+    // google meet
+    { KC_LGUI, KC_D, KC_NO },
+    { KC_LGUI, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    { KC_NO, KC_NO, KC_NO },
+    // rest
+    { KC_LGUI, KC_TAB, KC_NO },
+};
+
 const uint64_t icons[MATRIX_ROWS][MATRIX_COLS] = {
     {
         0,

--- a/keyboards/chonkerkeys/original/keymaps/default/config.c.template
+++ b/keyboards/chonkerkeys/original/keymaps/default/config.c.template
@@ -228,7 +228,7 @@ const uint16_t PROGMEM custom_actions[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS][3] 
     }
 };
 
-const rgb_strands_anim_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS] = {
+const uint8_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS] = {
     {
         {
             RGB_STRAND_EFFECT_NONE,

--- a/keyboards/chonkerkeys/original/keymaps/default/config.c.template
+++ b/keyboards/chonkerkeys/original/keymaps/default/config.c.template
@@ -5,6 +5,8 @@ const uint32_t firmware_version = 1;
 
 #define LAYER_COUNT 2
 
+const uint8_t layer_count = LAYER_COUNT;
+
 const uint8_t layers[LAYER_COUNT] = {
     CH_ZOOM_WINDOWS,
     CH_ZOOM_MACOS

--- a/keyboards/chonkerkeys/original/keymaps/default/keymap.c
+++ b/keyboards/chonkerkeys/original/keymaps/default/keymap.c
@@ -15,6 +15,4 @@
  */
 #include QMK_KEYBOARD_H
 #include "virtser.h"
-#include "../protocol.c"
 #include "config.c"
-#include "../core.c"

--- a/keyboards/chonkerkeys/original/original.c
+++ b/keyboards/chonkerkeys/original/original.c
@@ -14,4 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include QMK_KEYBOARD_H
+#include "virtser.h"
 #include "original.h"
+
+#include "../protocol.c"
+#include "../core.c"

--- a/keyboards/chonkerkeys/original/templates/chonkerkeys_original.json
+++ b/keyboards/chonkerkeys/original/templates/chonkerkeys_original.json
@@ -1,0 +1,9 @@
+{
+    "___comment": "PLACEHOLDER FOR NOW",
+    "keyboard": "chonkerkeys/original",
+    "keymap": "default",
+    "layout": "LAYOUT_all",
+    "layers": [
+        [], [], []
+    ]
+}

--- a/keyboards/chonkerkeys/original/templates/keymap.c
+++ b/keyboards/chonkerkeys/original/templates/keymap.c
@@ -1,0 +1,373 @@
+/**
+ * TODO: MAKE THIS CONFIGURABLE NOT HARD-CODED
+ */
+#include QMK_KEYBOARD_H
+#include "rgb_strands.h"
+
+// Defines the keycodes used by our macros in process_record_user
+enum custom_keycodes {
+    CH_CUSTOM = SAFE_RANGE,
+    // zoom
+    CH_ZOOM_MUTE_TOGGLE,
+    CH_ZOOM_VIDEO_TOGGLE,
+    CH_ZOOM_SHARE_SCREEN_START_STOP_TOGGLE,
+    CH_ZOOM_RAISE_HAND_TOGGLE,
+    CH_ZOOM_LEAVE_MEETING,
+    // teams
+    CH_TEAMS_MUTE_TOGGLE,
+    CH_TEAMS_VIDEO_TOGGLE,
+    CH_TEAMS_SHARE_SCREEN_START_STOP_TOGGLE,
+    CH_TEAMS_RAISE_HAND_TOGGLE,
+    CH_TEAMS_LEAVE_MEETING,
+    // skype
+    CH_SKYPE_MUTE_TOGGLE,
+    CH_SKYPE_VIDEO_TOGGLE,
+    CH_SKYPE_SHARE_SCREEN_START_STOP_TOGGLE,
+    CH_SKYPE_RAISE_HAND_TOGGLE,
+    CH_SKYPE_LEAVE_MEETING,
+    // google meet
+    CH_GOOGLE_MEET_MUTE_TOGGLE,
+    CH_GOOGLE_MEET_VIDEO_TOGGLE,
+    CH_GOOGLE_MEET_SHARE_SCREEN_START_STOP_TOGGLE,
+    CH_GOOGLE_MEET_RAISE_HAND_TOGGLE,
+    CH_GOOGLE_MEET_LEAVE_MEETING,
+    // rest
+    CH_SWITCH_WINDOW,
+    CH_LAST_KEYCODE
+};
+
+#define KEY_MACROS_MAX_COUNT  3
+#define KEYCODE_COUNT (CH_LAST_KEYCODE - CH_CUSTOM)
+
+const uint16_t windows_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LALT, KC_A, KC_NO },
+    { KC_LALT, KC_V, KC_NO },
+    { KC_LALT, KC_S, KC_NO },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LALT, KC_Q, KC_NO },
+    // teams
+    { KC_LCTRL, KC_LSHIFT, KC_M },
+    { KC_LCTRL, KC_LSHIFT, KC_O },
+    { KC_LCTRL, KC_LSHIFT, KC_E },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // skype
+    { KC_LCTRL, KC_M, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LSHIFT, KC_H },
+    // google meet
+    { KC_LCTRL, KC_D, KC_NO },
+    { KC_LCTRL, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LALT, KC_H },
+    { KC_LALT, KC_F4, KC_NO },
+    // rest
+    { KC_LALT, KC_TAB, KC_NO },
+};
+
+const uint16_t macos_configs[KEYCODE_COUNT][KEY_MACROS_MAX_COUNT] = {
+    { KC_NO, KC_NO, KC_NO },
+    // zoom
+    { KC_LGUI, KC_LSHIFT, KC_A },
+    { KC_LGUI, KC_LSHIFT, KC_V },
+    { KC_LGUI, KC_LSHIFT, KC_S },
+    { KC_LALT, KC_Y, KC_NO },
+    { KC_LGUI, KC_W, KC_NO },
+    // teams
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LCTRL, KC_LGUI, KC_O },
+    { KC_LCTRL, KC_LGUI, KC_E },
+    { KC_LCTRL, KC_LGUI, KC_K },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    // skype
+    { KC_LSHIFT, KC_LGUI, KC_M },
+    { KC_LSHIFT, KC_LGUI, KC_K },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LSHIFT, KC_LGUI, KC_H },
+    // google meet
+    { KC_LGUI, KC_D, KC_NO },
+    { KC_LGUI, KC_E, KC_NO },
+    { KC_NO, KC_NO, KC_NO },
+    { KC_LCTRL, KC_LGUI, KC_H },
+    { KC_NO, KC_NO, KC_NO },
+    // rest
+    { KC_LGUI, KC_TAB, KC_NO },
+};
+
+enum layer_type {
+    CH_CUSTOM_WINDOWS,
+    CH_CUSTOM_MACOS,
+    CH_ZOOM_WINDOWS,
+    CH_ZOOM_MACOS,
+    CH_TEAMS_WINDOWS,
+    CH_TEAMS_MACOS,
+    CH_SKYPE_WINDOWS,
+    CH_SKYPE_MACOS,
+    CH_GOOGLE_MEET_WINDOWS,
+    CH_GOOGLE_MEET_MACOS,
+};
+
+const uint32_t firmware_version = 1;
+
+#define LAYER_COUNT 2
+
+const uint8_t layer_count = LAYER_COUNT;
+
+const uint8_t layers[LAYER_COUNT] = {
+    CH_ZOOM_WINDOWS,
+    CH_ZOOM_MACOS
+};
+
+const uint64_t icons[MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        0,
+        0,
+        1280,
+        1024
+    },
+    {
+        768,
+        0,
+        512,
+        256
+    }
+};
+
+const uint8_t PROGMEM key_size_and_ordinals[MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        0,
+        0,
+        129,
+        1
+    },
+    {
+        1,
+        0,
+        67,
+        65
+    }
+};
+
+const uint32_t PROGMEM inactive_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        {
+            0,
+            0,
+            0,
+            0
+        },
+        {
+            4294901760,
+            0,
+            4278190080,
+            4278190080
+        }
+    },
+    {
+        {
+            0,
+            0,
+            0,
+            0
+        },
+        {
+            4294901760,
+            0,
+            4278190080,
+            4278190080
+        }
+    }
+};
+
+const uint32_t PROGMEM active_colors[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        {
+            4294967295,
+            4294967295,
+            4294967295,
+            16711680
+        },
+        {
+            16711680,
+            4294967295,
+            16711680,
+            16711680
+        }
+    },
+    {
+        {
+            4294967295,
+            4294967295,
+            4294967295,
+            16711680
+        },
+        {
+            16711680,
+            4294967295,
+            16711680,
+            16711680
+        }
+    }
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        {
+            KC_NO,
+            KC_NO,
+            CH_ZOOM_LEAVE_MEETING,
+            CH_ZOOM_RAISE_HAND_TOGGLE
+        },
+        {
+            CH_ZOOM_SHARE_SCREEN_START_STOP_TOGGLE,
+            KC_NO,
+            CH_ZOOM_VIDEO_TOGGLE,
+            CH_ZOOM_MUTE_TOGGLE
+        }
+    },
+    {
+        {
+            KC_NO,
+            KC_NO,
+            CH_ZOOM_LEAVE_MEETING,
+            CH_ZOOM_RAISE_HAND_TOGGLE
+        },
+        {
+            CH_ZOOM_SHARE_SCREEN_START_STOP_TOGGLE,
+            KC_NO,
+            CH_ZOOM_VIDEO_TOGGLE,
+            CH_ZOOM_MUTE_TOGGLE
+        }
+    }
+};
+
+const uint16_t PROGMEM custom_actions[LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS][3] = {
+    {
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        },
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        }
+    },
+    {
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        },
+        {
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            },
+            {
+                KC_NO,
+                KC_NO,
+                KC_NO
+            }
+        }
+    }
+};
+
+const uint8_t PROGMEM key_anim[][MATRIX_ROWS][MATRIX_COLS] = {
+    {
+        {
+            RGB_STRAND_EFFECT_NONE,
+            RGB_STRAND_EFFECT_NONE,
+            RGB_STRAND_EFFECT_DRAINSWIRL,
+            RGB_STRAND_EFFECT_LIKE
+        },
+        {
+            RGB_STRAND_EFFECT_BLINKY,
+            RGB_STRAND_EFFECT_NONE,
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_MOMENTARY
+        }
+    },
+    {
+        {
+            RGB_STRAND_EFFECT_NONE,
+            RGB_STRAND_EFFECT_NONE,
+            RGB_STRAND_EFFECT_DRAINSWIRL,
+            RGB_STRAND_EFFECT_LIKE
+        },
+        {
+            RGB_STRAND_EFFECT_BLINKY,
+            RGB_STRAND_EFFECT_NONE,
+            RGB_STRAND_EFFECT_MOMENTARY,
+            RGB_STRAND_EFFECT_MOMENTARY
+        }
+    }
+};

--- a/quantum/rgb_strands/rgb_strands.c
+++ b/quantum/rgb_strands/rgb_strands.c
@@ -28,7 +28,7 @@
 static bool is_rgb_strands_initialized = false;
 
 typedef struct _rgb_strand_anim_status_t {
-    rgb_strands_anim_t       effect;
+    uint8_t                  effect;
     rgb_strand_anim_config_t config;
     uint16_t                 nexttime;
     struct {
@@ -84,7 +84,7 @@ static rgb_strand_anim_config_t default_configs[] = {
     {} // RGB_STRAND_EFFECT_INVALID
 };
 
-const rgb_strand_anim_config_t * get_default_rgb_strand_anim_config(rgb_strands_anim_t anim) {
+const rgb_strand_anim_config_t * get_default_rgb_strand_anim_config(uint8_t anim) {
     if (anim <= RGB_STRAND_EFFECT_NONE || anim >= RGB_STRAND_EFFECT_INVALID) {
         return NULL;
     }
@@ -269,7 +269,7 @@ void rgb_strand_set_color(uint8_t strand, uint8_t h, uint8_t s, uint8_t v) {
 
 void rgb_strand_animation_start(
         uint8_t strand,
-        rgb_strands_anim_t effect,
+        uint8_t effect,
         const rgb_strand_anim_config_t *config,
         rgb_strand_anim_state_t initial_state) {
     if (!is_valid_strand(strand)) return;

--- a/quantum/rgb_strands/rgb_strands.h
+++ b/quantum/rgb_strands/rgb_strands.h
@@ -71,7 +71,7 @@ typedef enum {
     RGB_STRAND_ANIM_STATE_BREATHING = 2,
  } rgb_strand_anim_state_t;
 
-const rgb_strand_anim_config_t * get_default_rgb_strand_anim_config(rgb_strands_anim_t anim);
+const rgb_strand_anim_config_t * get_default_rgb_strand_anim_config(uint8_t anim);
 
 bool is_valid_strand(uint8_t strand);
 
@@ -86,7 +86,7 @@ void rgb_strand_set_color(uint8_t strand, uint8_t r, uint8_t g, uint8_t b);
 /** Start animation on the strand. Config is optional */
 void rgb_strand_animation_start(
         uint8_t strand,
-        rgb_strands_anim_t effect,
+        uint8_t anim,
         const rgb_strand_anim_config_t *config,
         rgb_strand_anim_state_t initial_state);
 


### PR DESCRIPTION
Re-arranged the ChonkerKeys source code to support the typical way of compiling from JSON in QMK, i.e. `qmk compile <json>` . This will make implementing remote compiling much easier.